### PR TITLE
fix: dedupe same-snapshot stats triggers

### DIFF
--- a/api/v1alpha1/backrestvolsyncbinding_types.go
+++ b/api/v1alpha1/backrestvolsyncbinding_types.go
@@ -61,14 +61,16 @@ type BackrestVolSyncBindingStatus struct {
 	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
 	Conditions         []metav1.Condition `json:"conditions,omitempty"`
 
-	ResolvedRepositorySecret  string       `json:"resolvedRepositorySecret,omitempty"`
-	LastAppliedInputHash      string       `json:"lastAppliedInputHash,omitempty"`
-	LastApplyTime             *metav1.Time `json:"lastApplyTime,omitempty"`
-	LastErrorHash             string       `json:"lastErrorHash,omitempty"`
-	LastIndexedSnapshotMarker string       `json:"lastIndexedSnapshotMarker,omitempty"`
-	LastSnapshotMarker        string       `json:"lastSnapshotMarker,omitempty"`
-	LastRepoTaskTriggerTime   *metav1.Time `json:"lastRepoTaskTriggerTime,omitempty"`
-	LastRepoTaskErrorHash     string       `json:"lastRepoTaskErrorHash,omitempty"`
+	ResolvedRepositorySecret    string       `json:"resolvedRepositorySecret,omitempty"`
+	LastAppliedInputHash        string       `json:"lastAppliedInputHash,omitempty"`
+	LastApplyTime               *metav1.Time `json:"lastApplyTime,omitempty"`
+	LastErrorHash               string       `json:"lastErrorHash,omitempty"`
+	LastIndexedSnapshotMarker   string       `json:"lastIndexedSnapshotMarker,omitempty"`
+	LastIndexedSnapshotSyncTime string       `json:"lastIndexedSnapshotSyncTime,omitempty"`
+	LastSnapshotMarker          string       `json:"lastSnapshotMarker,omitempty"`
+	LastSnapshotSyncTime        string       `json:"lastSnapshotSyncTime,omitempty"`
+	LastRepoTaskTriggerTime     *metav1.Time `json:"lastRepoTaskTriggerTime,omitempty"`
+	LastRepoTaskErrorHash       string       `json:"lastRepoTaskErrorHash,omitempty"`
 }
 
 // DeepCopyInto, DeepCopy, and DeepCopyObject are implemented manually to avoid requiring codegen.
@@ -79,13 +81,15 @@ func (in *BackrestVolSyncBinding) DeepCopyInto(out *BackrestVolSyncBinding) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
 	out.Status = BackrestVolSyncBindingStatus{
-		ObservedGeneration:        in.Status.ObservedGeneration,
-		ResolvedRepositorySecret:  in.Status.ResolvedRepositorySecret,
-		LastAppliedInputHash:      in.Status.LastAppliedInputHash,
-		LastErrorHash:             in.Status.LastErrorHash,
-		LastIndexedSnapshotMarker: in.Status.LastIndexedSnapshotMarker,
-		LastSnapshotMarker:        in.Status.LastSnapshotMarker,
-		LastRepoTaskErrorHash:     in.Status.LastRepoTaskErrorHash,
+		ObservedGeneration:          in.Status.ObservedGeneration,
+		ResolvedRepositorySecret:    in.Status.ResolvedRepositorySecret,
+		LastAppliedInputHash:        in.Status.LastAppliedInputHash,
+		LastErrorHash:               in.Status.LastErrorHash,
+		LastIndexedSnapshotMarker:   in.Status.LastIndexedSnapshotMarker,
+		LastIndexedSnapshotSyncTime: in.Status.LastIndexedSnapshotSyncTime,
+		LastSnapshotMarker:          in.Status.LastSnapshotMarker,
+		LastSnapshotSyncTime:        in.Status.LastSnapshotSyncTime,
+		LastRepoTaskErrorHash:       in.Status.LastRepoTaskErrorHash,
 	}
 	if in.Status.LastApplyTime != nil {
 		out.Status.LastApplyTime = in.Status.LastApplyTime.DeepCopy()

--- a/charts/backrest-volsync-operator/crds/backrestvolsyncbindings.backrest.garethgeorge.com.yaml
+++ b/charts/backrest-volsync-operator/crds/backrestvolsyncbindings.backrest.garethgeorge.com.yaml
@@ -88,7 +88,11 @@ spec:
                   type: string
                 lastIndexedSnapshotMarker:
                   type: string
+                lastIndexedSnapshotSyncTime:
+                  type: string
                 lastSnapshotMarker:
+                  type: string
+                lastSnapshotSyncTime:
                   type: string
                 lastRepoTaskTriggerTime:
                   type: string

--- a/config/all.yaml
+++ b/config/all.yaml
@@ -89,7 +89,11 @@ spec:
                   type: string
                 lastIndexedSnapshotMarker:
                   type: string
+                lastIndexedSnapshotSyncTime:
+                  type: string
                 lastSnapshotMarker:
+                  type: string
+                lastSnapshotSyncTime:
                   type: string
                 lastRepoTaskTriggerTime:
                   type: string

--- a/config/crd.yaml
+++ b/config/crd.yaml
@@ -88,7 +88,11 @@ spec:
                   type: string
                 lastIndexedSnapshotMarker:
                   type: string
+                lastIndexedSnapshotSyncTime:
+                  type: string
                 lastSnapshotMarker:
+                  type: string
+                lastSnapshotSyncTime:
                   type: string
                 lastRepoTaskTriggerTime:
                   type: string

--- a/controllers/backrestvolsyncbinding_controller.go
+++ b/controllers/backrestvolsyncbinding_controller.go
@@ -230,7 +230,7 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 		}
 	}
 
-	marker, ready, err := volsync.ReplicationSourceCompletionMarker(vsObj)
+	marker, syncTime, ready, err := volsync.ReplicationSourceCompletionMarker(vsObj)
 	if err != nil {
 		errHash := hashString(err.Error())
 		if binding.Status.LastRepoTaskErrorHash == errHash {
@@ -246,7 +246,7 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 	if !ready || marker == "" {
 		return false, nil
 	}
-	if binding.Status.LastSnapshotMarker == marker {
+	if snapshotTaskStateMatches(marker, syncTime, binding.Status.LastSnapshotMarker, binding.Status.LastSnapshotSyncTime) {
 		return false, nil
 	}
 
@@ -256,7 +256,7 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 	}
 
 	repoID := desiredRepoID(binding)
-	if binding.Status.LastIndexedSnapshotMarker != marker {
+	if !snapshotTaskStateMatches(marker, syncTime, binding.Status.LastIndexedSnapshotMarker, binding.Status.LastIndexedSnapshotSyncTime) {
 		if err := brClient.DoRepoTask(ctx, repoID, v1.DoRepoTaskRequest_TASK_INDEX_SNAPSHOTS); err != nil {
 			errHash := hashString(err.Error())
 			setTaskErrorHash(errHash)
@@ -274,6 +274,7 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 			return statusChanged, releaseTaskTrigger
 		}
 		binding.Status.LastIndexedSnapshotMarker = marker
+		binding.Status.LastIndexedSnapshotSyncTime = syncTime
 		statusChanged = true
 	}
 
@@ -296,6 +297,7 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 
 	now := metav1.Now()
 	binding.Status.LastSnapshotMarker = marker
+	binding.Status.LastSnapshotSyncTime = syncTime
 	binding.Status.LastRepoTaskTriggerTime = &now
 	if binding.Status.LastRepoTaskErrorHash != "" {
 		binding.Status.LastRepoTaskErrorHash = ""
@@ -311,6 +313,16 @@ func (r *BackrestVolSyncBindingReconciler) triggerSnapshotTasks(ctx context.Cont
 		"name", binding.Name,
 	)
 	return statusChanged, releaseTaskTrigger
+}
+
+func snapshotTaskStateMatches(marker, syncTime, storedMarker, storedSyncTime string) bool {
+	if marker != "" && storedMarker != "" && marker == storedMarker {
+		return true
+	}
+	if syncTime != "" && storedSyncTime != "" && syncTime == storedSyncTime {
+		return true
+	}
+	return false
 }
 
 func (r *BackrestVolSyncBindingReconciler) claimTaskTrigger(binding *v1alpha1.BackrestVolSyncBinding, marker string) (func(), bool) {

--- a/controllers/backrestvolsyncbinding_controller_test.go
+++ b/controllers/backrestvolsyncbinding_controller_test.go
@@ -502,6 +502,93 @@ func TestBackrestVolSyncBindingReconcile_DoesNotRetriggerWhenOnlyLastSyncTimeCha
 	}
 }
 
+func TestBackrestVolSyncBindingReconcile_DoesNotRetriggerWhenSnapshotFieldChangesForSameSync(t *testing.T) {
+	ctx := context.Background()
+	scheme := bindingTestScheme(t)
+
+	b := &v1alpha1.BackrestVolSyncBinding{}
+	b.Namespace = "workload"
+	b.Name = "b"
+	b.Spec.Backrest.URL = "http://backrest.invalid"
+	b.Spec.Source = v1alpha1.VolSyncSourceRef{Kind: "ReplicationSource", Name: "demo"}
+	enabled := true
+	b.Spec.Repo.TriggerTasksOnSnapshot = &enabled
+
+	vs := &unstructured.Unstructured{}
+	vs.SetGroupVersionKind(schema.GroupVersionKind{Group: volsync.Group, Version: volsync.Version, Kind: "ReplicationSource"})
+	vs.SetNamespace("workload")
+	vs.SetName("demo")
+	vs.SetUID(types.UID("1111"))
+	vs.Object = map[string]any{
+		"apiVersion": volsync.Group + "/" + volsync.Version,
+		"kind":       "ReplicationSource",
+		"metadata": map[string]any{
+			"name":      "demo",
+			"namespace": "workload",
+		},
+		"spec": map[string]any{
+			"restic": map[string]any{
+				"repository": "repo-secret",
+			},
+		},
+		"status": map[string]any{
+			"lastSyncTime": "2026-02-24T12:00:00Z",
+			"lastSnapshot": "snap-1",
+		},
+	}
+
+	sec := &corev1.Secret{}
+	sec.Namespace = "workload"
+	sec.Name = "repo-secret"
+	sec.Data = map[string][]byte{
+		"RESTIC_REPOSITORY": []byte("s3://bucket/repo"),
+		"RESTIC_PASSWORD":   []byte("pass"),
+	}
+	sec.SetUID(types.UID("2222"))
+	sec.SetResourceVersion("1")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.BackrestVolSyncBinding{}).
+		WithObjects(b, vs, sec).
+		Build()
+
+	br := &fakeBackrestRepoClient{}
+	r := &BackrestVolSyncBindingReconciler{
+		Client: c,
+		Scheme: scheme,
+		BackrestClientFactory: func(_ string, _ backrest.Auth) backrestRepoClient {
+			return br
+		},
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: b.Namespace, Name: b.Name}}); err != nil {
+		t.Fatalf("reconcile #1: %v", err)
+	}
+	if len(br.taskCalls) != 2 {
+		t.Fatalf("expected 2 task calls after first snapshot trigger, got %d", len(br.taskCalls))
+	}
+
+	var vsUpdated unstructured.Unstructured
+	vsUpdated.SetGroupVersionKind(schema.GroupVersionKind{Group: volsync.Group, Version: volsync.Version, Kind: "ReplicationSource"})
+	if err := c.Get(ctx, types.NamespacedName{Namespace: "workload", Name: "demo"}, &vsUpdated); err != nil {
+		t.Fatalf("get volsync object: %v", err)
+	}
+	delete(vsUpdated.Object["status"].(map[string]any), "lastSnapshot")
+	if err := unstructured.SetNestedField(vsUpdated.Object, "snap-1", "status", "lastSnapshotID"); err != nil {
+		t.Fatalf("set status.lastSnapshotID: %v", err)
+	}
+	if err := c.Update(ctx, &vsUpdated); err != nil {
+		t.Fatalf("update volsync object: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: b.Namespace, Name: b.Name}}); err != nil {
+		t.Fatalf("reconcile #2: %v", err)
+	}
+	if len(br.taskCalls) != 2 {
+		t.Fatalf("expected no additional task calls when only the snapshot field changes, got %d", len(br.taskCalls))
+	}
+}
+
 func TestBackrestVolSyncBindingReconcile_DeduplicatesConcurrentSnapshotTriggers(t *testing.T) {
 	ctx := context.Background()
 	scheme := bindingTestScheme(t)

--- a/pkg/volsync/extract.go
+++ b/pkg/volsync/extract.go
@@ -23,12 +23,21 @@ func RepositorySecretName(obj *unstructured.Unstructured) (string, error) {
 	return secretName, nil
 }
 
-func ReplicationSourceCompletionMarker(obj *unstructured.Unstructured) (string, bool, error) {
+func ReplicationSourceCompletionMarker(obj *unstructured.Unstructured) (string, string, bool, error) {
 	if obj == nil {
-		return "", false, fmt.Errorf("volsync object is nil")
+		return "", "", false, fmt.Errorf("volsync object is nil")
 	}
 	if obj.GetKind() != "ReplicationSource" {
-		return "", false, nil
+		return "", "", false, nil
+	}
+
+	lastSyncTime, found, err := unstructured.NestedString(obj.Object, "status", "lastSyncTime")
+	if err != nil {
+		return "", "", false, fmt.Errorf("read status.lastSyncTime: %w", err)
+	}
+	lastSyncTime = strings.TrimSpace(lastSyncTime)
+	if !found {
+		lastSyncTime = ""
 	}
 
 	for _, p := range []struct {
@@ -42,22 +51,16 @@ func ReplicationSourceCompletionMarker(obj *unstructured.Unstructured) (string, 
 	} {
 		v, found, err := unstructured.NestedString(obj.Object, p.path...)
 		if err != nil {
-			return "", false, fmt.Errorf("read %s: %w", strings.Join(p.path, "."), err)
+			return "", "", false, fmt.Errorf("read %s: %w", strings.Join(p.path, "."), err)
 		}
 		v = strings.TrimSpace(v)
 		if found && v != "" {
-			return p.key + "=" + v, true, nil
+			return p.key + "=" + v, lastSyncTime, true, nil
 		}
 	}
-
-	lastSyncTime, found, err := unstructured.NestedString(obj.Object, "status", "lastSyncTime")
-	if err != nil {
-		return "", false, fmt.Errorf("read status.lastSyncTime: %w", err)
-	}
-	lastSyncTime = strings.TrimSpace(lastSyncTime)
 	if found && lastSyncTime != "" {
-		return "lastSyncTime=" + lastSyncTime, true, nil
+		return "lastSyncTime=" + lastSyncTime, lastSyncTime, true, nil
 	}
 
-	return "", false, nil
+	return "", "", false, nil
 }

--- a/pkg/volsync/extract_test.go
+++ b/pkg/volsync/extract_test.go
@@ -64,7 +64,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 
 	t.Run("non source ignored", func(t *testing.T) {
 		obj := mk("ReplicationDestination", map[string]any{})
-		marker, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker, syncTime, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -73,12 +73,15 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		}
 		if marker != "" {
 			t.Fatalf("expected empty marker, got %q", marker)
+		}
+		if syncTime != "" {
+			t.Fatalf("expected empty syncTime, got %q", syncTime)
 		}
 	})
 
 	t.Run("no status fields", func(t *testing.T) {
 		obj := mk("ReplicationSource", map[string]any{"status": map[string]any{}})
-		marker, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker, syncTime, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -87,6 +90,9 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		}
 		if marker != "" {
 			t.Fatalf("expected empty marker, got %q", marker)
+		}
+		if syncTime != "" {
+			t.Fatalf("expected empty syncTime, got %q", syncTime)
 		}
 	})
 
@@ -96,7 +102,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 				"lastSyncTime": "2026-02-24T12:00:00Z",
 			},
 		})
-		marker, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker, syncTime, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -106,6 +112,9 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		expected := "lastSyncTime=2026-02-24T12:00:00Z"
 		if marker != expected {
 			t.Fatalf("expected %q, got %q", expected, marker)
+		}
+		if syncTime != "2026-02-24T12:00:00Z" {
+			t.Fatalf("expected syncTime to match lastSyncTime, got %q", syncTime)
 		}
 	})
 
@@ -120,7 +129,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 				},
 			},
 		})
-		marker, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker, syncTime, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -131,6 +140,9 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		if marker != expected {
 			t.Fatalf("expected %q, got %q", expected, marker)
 		}
+		if syncTime != "2026-02-24T12:00:00Z" {
+			t.Fatalf("expected syncTime preserved, got %q", syncTime)
+		}
 	})
 
 	t.Run("marker remains stable when only lastSyncTime changes", func(t *testing.T) {
@@ -140,7 +152,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 				"lastSnapshot": "snap-a",
 			},
 		})
-		marker1, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker1, syncTime1, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -149,7 +161,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		}
 
 		obj.Object["status"].(map[string]any)["lastSyncTime"] = "2026-02-24T12:05:00Z"
-		marker2, ready, err := ReplicationSourceCompletionMarker(obj)
+		marker2, syncTime2, ready, err := ReplicationSourceCompletionMarker(obj)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
@@ -160,6 +172,42 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 		if marker1 != "lastSnapshot=snap-a" || marker2 != "lastSnapshot=snap-a" {
 			t.Fatalf("expected stable snapshot marker, got marker1=%q marker2=%q", marker1, marker2)
 		}
+		if syncTime1 != "2026-02-24T12:00:00Z" || syncTime2 != "2026-02-24T12:05:00Z" {
+			t.Fatalf("expected sync times to reflect status changes, got syncTime1=%q syncTime2=%q", syncTime1, syncTime2)
+		}
+	})
+
+	t.Run("field transition keeps same sync time", func(t *testing.T) {
+		obj := mk("ReplicationSource", map[string]any{
+			"status": map[string]any{
+				"lastSyncTime": "2026-02-24T12:00:00Z",
+				"lastSnapshot": "snap-a",
+			},
+		})
+		marker1, syncTime1, ready, err := ReplicationSourceCompletionMarker(obj)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if !ready {
+			t.Fatalf("expected ready=true")
+		}
+
+		delete(obj.Object["status"].(map[string]any), "lastSnapshot")
+		obj.Object["status"].(map[string]any)["lastSnapshotID"] = "snap-a"
+		marker2, syncTime2, ready, err := ReplicationSourceCompletionMarker(obj)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if !ready {
+			t.Fatalf("expected ready=true")
+		}
+
+		if marker1 != "lastSnapshot=snap-a" || marker2 != "lastSnapshotID=snap-a" {
+			t.Fatalf("expected marker field transition, got marker1=%q marker2=%q", marker1, marker2)
+		}
+		if syncTime1 != "2026-02-24T12:00:00Z" || syncTime2 != "2026-02-24T12:00:00Z" {
+			t.Fatalf("expected syncTime to remain stable, got syncTime1=%q syncTime2=%q", syncTime1, syncTime2)
+		}
 	})
 
 	t.Run("wrong field type returns error", func(t *testing.T) {
@@ -168,7 +216,7 @@ func TestReplicationSourceCompletionMarker(t *testing.T) {
 				"lastSyncTime": 123,
 			},
 		})
-		_, _, err := ReplicationSourceCompletionMarker(obj)
+		_, _, _, err := ReplicationSourceCompletionMarker(obj)
 		if err == nil {
 			t.Fatalf("expected error")
 		}


### PR DESCRIPTION
## Summary
- store VolSync completion sync time alongside the derived snapshot marker
- treat a snapshot as already processed when either the marker or the completion sync time matches
- add regression coverage for same-snapshot field transitions and keep existing lastSyncTime churn protection

## Root cause
The operator only remembered the derived completion marker string. VolSync can report the same completed snapshot through different status fields over time, which changed the marker even though the snapshot was the same. That allowed a second successful STATS enqueue and produced duplicate stats rows.

## Fix
The controller now persists both the derived marker and the underlying status.lastSyncTime used for that completion. Snapshot task dedupe treats either match as the same already-processed completion, so later status-field transitions do not retrigger INDEX_SNAPSHOTS or STATS for the same snapshot.

## Validation
- make test
- make lint is blocked locally because the installed golangci-lint binary was built with an older Go version than the repo now targets (go1.25 vs go1.26.2)
